### PR TITLE
fix: tower-bullet-position, flameBullet layer order, changed flameTow…

### DIFF
--- a/Assets/Prefabs/Tower/TowerBulletPrefab/FlameBullet.prefab
+++ b/Assets/Prefabs/Tower/TowerBulletPrefab/FlameBullet.prefab
@@ -78,9 +78,9 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 10
+  m_SortingOrder: 9
   m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
-  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_Color: {r: 0.735849, g: 0.35751158, b: 0.35751158, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0

--- a/Assets/Prefabs/Tower/TowerPrefab/BasicTower.prefab
+++ b/Assets/Prefabs/Tower/TowerPrefab/BasicTower.prefab
@@ -76,7 +76,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 10
+  m_SortingOrder: 11
   m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
   m_Color: {r: 0, g: 1, b: 0.10618591, a: 1}
   m_FlipX: 0
@@ -101,10 +101,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   hp: 100
-  range: 10
   fireRate: 1
   bulletSpeed: 5
+  bulletDamage: 30
   towerPosition: {x: 0, y: 0, z: 0}
   targetPosition: {x: 0, y: 0, z: 0}
   bulletPrefab: {fileID: 4692455046652044710, guid: 8b5786322162c461f9d302f7082e538e, type: 3}
   damagePopupPrefab: {fileID: 2437635022160800495, guid: 57af91314f46b40ebace9c0eb458f01d, type: 3}
+  towerManager: {fileID: 0}
+  buttonSpawner: {fileID: 0}

--- a/Assets/Prefabs/Tower/TowerPrefab/FlameThrower.prefab
+++ b/Assets/Prefabs/Tower/TowerPrefab/FlameThrower.prefab
@@ -76,9 +76,9 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 10
+  m_SortingOrder: 11
   m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
-  m_Color: {r: 1, g: 0, b: 0.01999569, a: 1}
+  m_Color: {r: 0.33962262, g: 0.008009966, b: 0.014512234, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -101,10 +101,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   hp: 100
-  range: 10
   fireRate: 1
   bulletSpeed: 5
+  bulletDamage: 30
   towerPosition: {x: 0, y: 0, z: 0}
   targetPosition: {x: 0, y: 0, z: 0}
   bulletPrefab: {fileID: 5055650544199450120, guid: dbc563542628140cea3f502a6ca8b53f, type: 3}
   damagePopupPrefab: {fileID: 2437635022160800495, guid: 57af91314f46b40ebace9c0eb458f01d, type: 3}
+  towerManager: {fileID: 0}
+  buttonSpawner: {fileID: 0}

--- a/Assets/Scripts/Tower/Tower/FlameThrowerTower.cs
+++ b/Assets/Scripts/Tower/Tower/FlameThrowerTower.cs
@@ -13,7 +13,7 @@ public class FlameThrowerTower : TowerBase
 
     public override void ShootBullet(Vector3 targetPosition, float speed, int damage)
     {
-        GameObject bullet = Instantiate(bulletPrefab, towerPosition, Quaternion.identity);
+        GameObject bullet = Instantiate(bulletPrefab, transform.position, Quaternion.identity);
         FlameBullet bulletScript = bullet.GetComponent<FlameBullet>();
         if (bulletScript != null)
         {

--- a/Assets/Scripts/Tower/Tower/TowerBase.cs
+++ b/Assets/Scripts/Tower/Tower/TowerBase.cs
@@ -66,7 +66,7 @@ public class TowerBase : MonoBehaviour
 
     public virtual void ShootBullet(Vector3 targetPosition, float speed, int damage)
     {
-        GameObject bullet = Instantiate(bulletPrefab, towerPosition, Quaternion.identity);
+        GameObject bullet = Instantiate(bulletPrefab, transform.position, Quaternion.identity);
         BasicBullet bulletScript = bullet.GetComponent<BasicBullet>();
         if (bulletScript != null)
         {


### PR DESCRIPTION
- fix tower-bullet-position wrong
- change flameBullet layer order so that player can see other objs more clearly
- change falmeBullet and flameTower's color so that the damage popup could be seen clearly 